### PR TITLE
feat: 商品詳細頁購物車庫存下單限制、購買連結設定

### DIFF
--- a/src/views/ProductDetail/ProductDetail.vue
+++ b/src/views/ProductDetail/ProductDetail.vue
@@ -128,7 +128,7 @@
             加到購物車
           </button>
           <button
-            type="submit"
+            type="button"
             :disabled="isSoldOut"
             @click="buyNow"
             class="bg-[#6d654f] text-white text-sm p-3.5 rounded-md w-32 font-bold hover:bg-[#ABB7A5] disabled:bg-gray-400 disabled:cursor-not-allowed"


### PR DESCRIPTION
close #47
調整兩個按鈕(加入購物車、立即購買)及商品數量的設定：
1、設定下單數量不能高於庫存、防止使用者手動輸入違規數字
2、換頁數量會跳回1
3、擋庫存：庫存不足時，讓加入購物車跟立即購買按鈕變灰色不能按
<img width="563" height="682" alt="image" src="https://github.com/user-attachments/assets/f320feba-281d-4203-a2c5-35fe703b2c08" />
4、新增無庫存、低庫存提示 (有去資料庫做庫存調整)
<img width="591" height="687" alt="image" src="https://github.com/user-attachments/assets/60b617d4-f84e-43fb-b009-91a3d4ea0cc5" />
5、立即購買點下去連到結帳頁
6、移除收藏功能

*待登入頁完成才能做：立即購買點下去，如果偵測到使用者沒登入就讓他連去登入頁