### PR TITLE
feat: 進階模擬器 RWD 介面優化 (Mobile UI Refinements)

### DIFF
--- a/src/views/RefineSimulator/RefineSimulator.vue
+++ b/src/views/RefineSimulator/RefineSimulator.vue
@@ -1237,7 +1237,7 @@ let lastLogTime = 0;
                     <!-- Mobile: Top-Left Floating Box. Desktop: Relative block. -->
                     <div class="p-4 flex flex-col gap-3 transition-all duration-500 ease-in-out"
                          :class="isMobile 
-                            ? 'fixed top-24 left-2 w-56 max-h-[35vh] bg-[#fdfbf7]/95 backdrop-blur-xl shadow-2xl z-[60] border border-[#3e2723]/10 overflow-y-auto rounded-2xl' + (showMobileSettings ? ' translate-x-0 opacity-100 scale-100' : ' -translate-x-10 opacity-0 scale-95 pointer-events-none')
+                            ? 'fixed top-24 left-2 w-56 max-h-[35vh] bg-[#fdfbf7]/95 backdrop-blur-xl shadow-2xl z-[60] border border-[#3e2723]/10 flex flex-col overflow-hidden rounded-2xl' + (showMobileSettings ? ' translate-x-0 opacity-100 scale-100' : ' -translate-x-10 opacity-0 scale-95 pointer-events-none')
                             : 'relative w-full glass rounded-2xl opacity-100 scale-100'">
                             
                         <h2 class="text-xs font-bold uppercase tracking-wider text-[#8d6e63] border-b border-[#3e2723]/10 pb-2 flex justify-between">
@@ -1245,51 +1245,54 @@ let lastLogTime = 0;
                             <span v-if="isMobile" @click="showMobileSettings = false" class="text-lg leading-none cursor-pointer">×</span>
                         </h2>
                         
-                        <!-- Roast Level -->
-                        <div class="flex flex-col gap-1">
-                            <div class="flex justify-between text-[10px] text-[#3e2723]">
-                                <span>烘焙度 (Roast)</span>
-                                <span class="text-orange-600">{{ roastLabel }}</span>
+                        <!-- Content Wrapper for Scroll -->
+                        <div :class="isMobile ? 'flex-1 overflow-y-auto min-h-0 pr-1' : ''">
+                            <!-- Roast Level -->
+                            <div class="flex flex-col gap-1 mb-3">
+                                <div class="flex justify-between text-[10px] text-[#3e2723]">
+                                    <span>烘焙度 (Roast)</span>
+                                    <span class="text-orange-600">{{ roastLabel }}</span>
+                                </div>
+                                <input type="range" min="-1" max="1" step="0.1" v-model.number="roastLevel">
+                                <div class="flex justify-between text-[9px] text-[#8d6e63]">
+                                    <span>淺 (Light)</span>
+                                    <span>深 (Dark)</span>
+                                </div>
                             </div>
-                            <input type="range" min="-1" max="1" step="0.1" v-model.number="roastLevel">
-                            <div class="flex justify-between text-[9px] text-[#8d6e63]">
-                                <span>淺 (Light)</span>
-                                <span>深 (Dark)</span>
-                            </div>
-                        </div>
 
-                        <!-- Grind Level -->
-                        <div class="flex flex-col gap-1">
-                            <div class="flex justify-between text-[10px] text-[#3e2723]">
-                                <span>研磨度 (Grind)</span>
-                                <span class="text-orange-600">{{ grindLabel }}</span>
+                            <!-- Grind Level -->
+                            <div class="flex flex-col gap-1 mb-3">
+                                <div class="flex justify-between text-[10px] text-[#3e2723]">
+                                    <span>研磨度 (Grind)</span>
+                                    <span class="text-orange-600">{{ grindLabel }}</span>
+                                </div>
+                                <input type="range" min="-1" max="1" step="0.1" v-model.number="grindLevel">
+                                <div class="flex justify-between text-[9px] text-[#8d6e63]">
+                                    <span>細 (Fine)</span>
+                                    <span>粗 (Coarse)</span>
+                                </div>
                             </div>
-                            <input type="range" min="-1" max="1" step="0.1" v-model.number="grindLevel">
-                            <div class="flex justify-between text-[9px] text-[#8d6e63]">
-                                <span>細 (Fine)</span>
-                                <span>粗 (Coarse)</span>
-                            </div>
-                        </div>
 
-                        <!-- Live Stats -->
-                        <div class="space-y-1 pt-2 border-t border-[#3e2723]/10 text-[#3e2723]">
-                            <div class="flex justify-between text-[10px]">
-                                <span class="opacity-60">水量 (Water)</span>
-                                <span class="font-mono">{{ Math.round(totalWater) }}ml</span>
-                            </div>
-                            <div class="flex justify-between text-[10px]">
-                                <span class="opacity-60">注水次數 (Pours)</span>
-                                <span class="font-mono">{{ pours }}</span>
-                            </div>
-                            <div class="flex justify-between text-[10px]">
-                                <span class="opacity-60">粉水比 (Ratio)</span>
-                                <span class="font-mono">1:{{ currentRatio }}</span>
+                            <!-- Live Stats -->
+                            <div class="space-y-1 pt-2 border-t border-[#3e2723]/10 text-[#3e2723]">
+                                <div class="flex justify-between text-[10px]">
+                                    <span class="opacity-60">水量 (Water)</span>
+                                    <span class="font-mono">{{ Math.round(totalWater) }}ml</span>
+                                </div>
+                                <div class="flex justify-between text-[10px]">
+                                    <span class="opacity-60">注水次數 (Pours)</span>
+                                    <span class="font-mono">{{ pours }}</span>
+                                </div>
+                                <div class="flex justify-between text-[10px]">
+                                    <span class="opacity-60">粉水比 (Ratio)</span>
+                                    <span class="font-mono">1:{{ currentRatio }}</span>
+                                </div>
                             </div>
                         </div>
                         
-                        <!-- Mobile Back Button (Bottom Left) -->
-                        <div v-if="isMobile" class="mt-4 pt-4 border-t border-[#3e2723]/10">
-                            <button @click="showMobileSettings = false" class="flex items-center gap-2 text-[#3e2723] hover:bg-[#3e2723]/10 px-3 py-2 rounded-lg transition-colors font-bold">
+                        <!-- Mobile Back Button (Sticky Bottom) -->
+                        <div v-if="isMobile" class="mt-auto pt-2 border-t border-[#3e2723]/10">
+                            <button @click="showMobileSettings = false" class="w-full flex justify-center items-center gap-2 text-[#3e2723] hover:bg-[#3e2723]/10 px-3 py-2 rounded-lg transition-colors font-bold">
                                 <span class="text-xl">&lt;</span>
                                 <span class="text-xs">返回 (Back)</span>
                             </button>
@@ -1400,7 +1403,7 @@ let lastLogTime = 0;
                     <!-- Mobile: Bottom-Left Floating Box. Desktop: Relative block. -->
                     <div class="p-3 flex flex-col gap-3 transition-all duration-500 ease-in-out"
                          :class="isMobile 
-                            ? 'fixed bottom-24 left-2 w-56 max-h-[35vh] bg-[#fdfbf7]/95 backdrop-blur-xl shadow-2xl z-[60] border border-[#3e2723]/10 overflow-y-auto rounded-2xl' + (showMobileStats ? ' translate-x-0 opacity-100 scale-100' : ' -translate-x-10 opacity-0 scale-95 pointer-events-none')
+                            ? 'fixed bottom-24 left-2 w-56 max-h-[35vh] bg-[#fdfbf7]/95 backdrop-blur-xl shadow-2xl z-[60] border border-[#3e2723]/10 flex flex-col overflow-hidden rounded-2xl' + (showMobileStats ? ' translate-x-0 opacity-100 scale-100' : ' -translate-x-10 opacity-0 scale-95 pointer-events-none')
                             : 'relative w-full glass rounded-xl opacity-100 scale-100'">
 
                         <h3 class="text-[9px] font-bold uppercase tracking-widest text-[#8d6e63] border-b border-[#3e2723]/10 pb-1 flex justify-between">
@@ -1408,56 +1411,59 @@ let lastLogTime = 0;
                             <span v-if="isMobile" @click="showMobileStats = false" class="text-lg leading-none cursor-pointer">×</span>
                         </h3>
                         
-                        <!-- Extraction Bar -->
-                        <div class="flex flex-col gap-1">
-                            <div class="flex justify-between items-baseline text-[10px]">
-                                <span class="text-[#3e2723]">萃取狀態 (Extraction)</span>
-                                <span class="font-bold text-[9px]" :class="extractionVisual.valNum > 0.25 ? 'text-red-600' : (extractionVisual.valNum < -0.25 ? 'text-blue-600' : 'text-emerald-700')">
-                                    {{ extractionVisual.label }}
-                                </span>
+                        <!-- Content Wrapper for Scroll -->
+                        <div :class="isMobile ? 'flex-1 overflow-y-auto min-h-0 pr-1' : ''">
+                            <!-- Extraction Bar -->
+                            <div class="flex flex-col gap-1 mb-3">
+                                <div class="flex justify-between items-baseline text-[10px]">
+                                    <span class="text-[#3e2723]">萃取狀態 (Extraction)</span>
+                                    <span class="font-bold text-[9px]" :class="extractionVisual.valNum > 0.25 ? 'text-red-600' : (extractionVisual.valNum < -0.25 ? 'text-blue-600' : 'text-emerald-700')">
+                                        {{ extractionVisual.label }}
+                                    </span>
+                                </div>
+                                <div class="relative w-full h-2 bg-gray-200 rounded-full overflow-hidden border border-white/40">
+                                    <div class="absolute left-1/2 top-0 bottom-0 w-0.5 bg-[#3e2723]/20 z-10 transform -translate-x-1/2"></div>
+                                    <div class="h-full transition-all duration-300 ease-out"
+                                         :class="extractionVisual.colorClass"
+                                         :style="{ width: extractionVisual.pct + '%' }">
+                                    </div>
+                                </div>
                             </div>
-                            <div class="relative w-full h-2 bg-gray-200 rounded-full overflow-hidden border border-white/40">
-                                <div class="absolute left-1/2 top-0 bottom-0 w-0.5 bg-[#3e2723]/20 z-10 transform -translate-x-1/2"></div>
-                                <div class="h-full transition-all duration-300 ease-out"
-                                     :class="extractionVisual.colorClass"
-                                     :style="{ width: extractionVisual.pct + '%' }">
+
+                            <!-- Uniformity Bar -->
+                            <div class="flex flex-col gap-1 mb-3">
+                                <div class="flex justify-between items-baseline text-[10px]">
+                                    <span class="text-[#3e2723]">均勻度 (Uniformity)</span>
+                                    <span class="font-bold text-[9px] text-[#3e2723]">{{ uniformityVisual.label }}</span>
+                                </div>
+                                <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden border border-white/40">
+                                    <div class="h-full transition-all duration-300 ease-out"
+                                         :class="uniformityVisual.colorClass"
+                                         :style="{ width: uniformityVisual.pct + '%' }">
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- 2. Flavor Radar (Inside Stats Panel on Mobile) -->
+                            <div class="w-full h-40 p-1 rounded-lg flex items-center justify-center relative bg-white/20 mb-3">
+                                <canvas id="radarChart"></canvas>
+                            </div>
+
+                            <!-- 3. Extraction Graph (Inside Stats Panel on Mobile) -->
+                            <div class="w-full h-32 p-1 rounded-lg relative flex flex-col bg-white/20">
+                                <div class="flex justify-between items-center mb-1">
+                                    <h3 class="text-[9px] uppercase tracking-widest text-[#8d6e63]">總水量 / 時間</h3>
+                                    <span class="text-[9px] text-blue-700">Target: {{ predictedYield }}%</span>
+                                </div>
+                                <div class="relative flex-1 w-full h-full overflow-hidden">
+                                    <canvas id="lineChart"></canvas>
                                 </div>
                             </div>
                         </div>
 
-                        <!-- Uniformity Bar -->
-                        <div class="flex flex-col gap-1">
-                            <div class="flex justify-between items-baseline text-[10px]">
-                                <span class="text-[#3e2723]">均勻度 (Uniformity)</span>
-                                <span class="font-bold text-[9px] text-[#3e2723]">{{ uniformityVisual.label }}</span>
-                            </div>
-                            <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden border border-white/40">
-                                <div class="h-full transition-all duration-300 ease-out"
-                                     :class="uniformityVisual.colorClass"
-                                     :style="{ width: uniformityVisual.pct + '%' }">
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- 2. Flavor Radar (Inside Stats Panel on Mobile) -->
-                        <div class="w-full h-40 p-1 rounded-lg flex items-center justify-center relative bg-white/20">
-                            <canvas id="radarChart"></canvas>
-                        </div>
-
-                        <!-- 3. Extraction Graph (Inside Stats Panel on Mobile) -->
-                        <div class="w-full h-32 p-1 rounded-lg relative flex flex-col bg-white/20">
-                            <div class="flex justify-between items-center mb-1">
-                                <h3 class="text-[9px] uppercase tracking-widest text-[#8d6e63]">總水量 / 時間</h3>
-                                <span class="text-[9px] text-blue-700">Target: {{ predictedYield }}%</span>
-                            </div>
-                            <div class="relative flex-1 w-full h-full overflow-hidden">
-                                <canvas id="lineChart"></canvas>
-                            </div>
-                        </div>
-
-                        <!-- Mobile Back Button (Bottom Left) -->
-                        <div v-if="isMobile" class="mt-4 pt-4 border-t border-[#3e2723]/10">
-                            <button @click="showMobileStats = false" class="flex items-center gap-2 text-[#3e2723] hover:bg-[#3e2723]/10 px-3 py-2 rounded-lg transition-colors font-bold">
+                        <!-- Mobile Back Button (Sticky Bottom) -->
+                        <div v-if="isMobile" class="mt-auto pt-2 border-t border-[#3e2723]/10">
+                            <button @click="showMobileStats = false" class="w-full flex justify-center items-center gap-2 text-[#3e2723] hover:bg-[#3e2723]/10 px-3 py-2 rounded-lg transition-colors font-bold">
                                 <span class="text-xl">&lt;</span>
                                 <span class="text-xs">返回 (Back)</span>
                             </button>


### PR DESCRIPTION
## 📱 Mobile UI Refinements (進階模擬器 RWD 優化)

此 PR 包含了針對 `RefineSimulator.vue` 手機版介面的優化調整，旨在解決 UI 元素遮擋與操作不便的問題。

### 🛠️ 修改內容 (Changes)

1.  **Brewing Guide (沖煮指引) & Coffee Fairy (小精靈)**
    - 縮減手機版寬度至 `70%` (原為 `90%`)。
    - 增加最大寬度限制 `max-w-[280px]` 與 `scale-90` 縮放。
    - **目的**：避免遮擋左側的「設定」與「分析」按鈕。

2.  **Settings & Analysis Panels (設定與分析面板)**
    - 改採用 `flex-col` 直式佈局。
    - 內容區塊設置為 `overflow-y-auto` 可獨立滾動。
    - **Back Button (返回按鈕)**：固定於面板底部 (`mt-auto`)。
    - **目的**：確保返回按鈕隨時可見，不需要滑動到底部才能關閉面板，提升操作體驗。

### ✅ 測試 (Testing)
- 請在手機寬度下測試「設定」與「分析」面板的開啟與關閉。
- 確認「沖煮指引」不會蓋到左側按鈕。